### PR TITLE
Expose also old primary aggregate to handler-fn for observers

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,6 +58,9 @@ A Clojure foundation for CQRS/Event Sourcing.
    views on event streams.
 
 * Changelog
+  - 0.3.0-SNAPSHOT
+    - Provide also the old primary aggregate to handler function for
+      observers. Bump version for breaking changes
 
   - 0.2.0-RC4
     - Fix exception reporting for non-SQLExceptions

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rill/rill "0.2.0-RC5"
+(defproject rill/rill "0.3.0-SNAPSHOT"
   :description "An Event Sourcing Toolkit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rill/rill "0.2.0-RC4"
+(defproject rill/rill "0.2.0-RC5"
   :description "An Event Sourcing Toolkit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}


### PR DESCRIPTION
Breaking change that exposes also the primary aggregate as it was (i.e. before applying `update-aggregate`) to the handler function for the observers.

Fixes #7 
