### PR TITLE
create macros event/command/message that allow custom message type

### DIFF
--- a/test/rill/aggregate_test.clj
+++ b/test/rill/aggregate_test.clj
@@ -41,9 +41,9 @@
   custom-ag-id)
 
 (deftest custom-aggregate-id
-  (let [e (custom-agg-id-event "foo" "bar")]
-    (is (= (custom-ag-id e)
-           (primary-aggregate-id e)))))
+  (let [event (custom-agg-id-event "foo" "bar")]
+    (is (= (custom-ag-id event)
+           (primary-aggregate-id event)))))
 
 (def my-aggregate-id 2798)
 

--- a/test/rill/message_test.clj
+++ b/test/rill/message_test.clj
@@ -11,12 +11,21 @@
 (defmessage FooMessage
   :my-id s/Int)
 
+(def bar-message
+  (message/message :msg/BarMessage
+    :my-id s/Int))
+
 (deftest test-defmessage
   (testing "generated constructors"
     (is (= (message/type (foo-message 456))
            ::FooMessage))
     (is (= (:my-id (foo-message 456))
            456))
+    (is (= (message/type (bar-message 123))
+           :msg/BarMessage))
+    (is (= (:my-id (bar-message 123))
+           123))
+
     (is (message/id (foo-message 1)))
     (is (not= (message/id (foo-message 1))
               (message/id (foo-message 1))))
@@ -25,4 +34,3 @@
       (Thread/sleep 22)
       (let [t2 (message/timestamp (foo-message 1))]
         (is (not= t1 t2))))))
-


### PR DESCRIPTION
I've added a new macro `message` to the rill.message ns. (And `event` and `command` which are aliases)

`message` will extend the primary-aggregate-id multimethod and return an anonymous fn that creates a message of the given type. It works exactly as defmessage, except that you can supply your own type that is not tied to the namespace where you called it from and it doesn't have a docstring (as we don't create the var like defmessage does.

`defmessage` works the same as before and calls/expands `message` internally.

Usage:

``` clojure
(use 'rill.message)

(def create-user!
  (command :user/Create!
    :id s/UUID
    :name s/Str))

(def user-created
  (event :user/Created
    :id s/UUID
    :name s/Str))

(create-user! (rill.uuid/new-id) "Godzilla")
;; => {:rill.message/timestamp #inst"2015-12-13T14:07:29.666-00:00",
;;     :rill.message/id #uuid"89a8a9d8-5a26-4489-bd4d-3ffde6dfe1c0",
;;     :rill.message/type :user/Create!,
;;     :name "Godzilla",
;;     :id #uuid"eaceb72d-cd6c-4c9d-8a28-e4f51b0226a6"}

;; etc
```
